### PR TITLE
chore: raise start version to v3.6.15

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -3,24 +3,6 @@
   "depName": "python",
   "datasource": "docker",
   "versioning": "docker",
-  "startVersion": "2.7.13",
-  "ignoredVersions": [
-    "3.2.6",
-    "3.3.5",
-    "3.3.6",
-    "3.3.7",
-    "3.4.1",
-    "3.4.2",
-    "3.4.3",
-    "3.4.4",
-    "3.4.5",
-    "3.4.6",
-    "3.4.7",
-    "3.4.8",
-    "3.4.9",
-    "3.4.10",
-    "3.5.0",
-    "3.5.1",
-    "3.5.2"
-  ]
+  "startVersion": "3.6.15",
+  "ignoredVersions": []
 }


### PR DESCRIPTION
We won't get older versions as everything below 3.6 is already EOL